### PR TITLE
fix: let renovate update node version in k8s/.nvmrc

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "rebaseWhen": "auto"
+    },
+    {
+      "description": "Update node version in .nvmrc file",
+      "matchManagers": ["nvm"],
+      "matchFileNames": ["k8s/.nvmrc"],
+      "versioning": "node"
     }
   ]
 }


### PR DESCRIPTION
Using this project to test the renovate config change for auto updating the k8s node version in .nvmrc file